### PR TITLE
chore: set up SonarQube code analysis

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+name: SonarQube Main Workflow
+jobs:
+  sonarqube:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Run SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@master # @master tag vs. commit hash is the prescribed pattern by our security team for sonarsource/
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      - name: Quality Gate Check
+        uses: sonarsource/sonarqube-quality-gate-action@master # @master tag vs. commit hash is the prescribed pattern by our security team for sonarsource/
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+# Server and project configuration
+# Note: SONAR_HOST_URL is also passed at scan time. This entry documents the
+# expected host and is a no-op when the runtime value takes precedence.
+sonar.host.url=https://sonar.wpengine.io/
+sonar.projectVersion=1.0
+sonar.sourceEncoding=UTF-8
+sonar.scm.provider=git
+
+# Project identifiers
+sonar.projectName=local-addon-headless
+sonar.projectKey=getflywheel_local-addon-headless_65b8a866-67f3-4c01-8932-7fda462f53fd
+
+# Paths to source code directories (relative paths)
+sonar.sources=src
+
+# Exclusions — test files and compiled output
+sonar.exclusions=**/*.test.*,**/*.spec.*,node_modules/**,lib/**
+
+# Paths to test code directories (relative paths)
+sonar.tests=.
+sonar.test.inclusions=**/*.test.*,**/*.spec.*


### PR DESCRIPTION
## Summary

- Adds `sonar-project.properties` with project key `getflywheel_local-addon-headless_65b8a866-67f3-4c01-8932-7fda462f53fd`
- Adds `.github/workflows/sonar.yaml` — runs SonarQube scan + quality gate on all PRs and pushes to `master`
- Static analysis only (no duplicate test run)

## Test plan

- [ ] Confirm the `sonarqube` GitHub Actions job passes on this PR
- [ ] Confirm `SonarQube Code Analysis` check is posted by the SonarQube GitHub App
- [ ] Review findings in the SonarQube dashboard after the scan completes